### PR TITLE
Update for Mongoose 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+coverage
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ UserSchema.plugin(filter, {
   },
   // 'nofilter' is a built-in filter that does no processing, be careful with this
   defaultFilterRole: 'nofilter',
-  sanitize: true // Escape HTML in strings
+  sanitize: true, // Escape HTML in strings
+  compat: true // Enable compatibility for Mongoose versions prior to 3.6 (default false)
 });
 ```
 
@@ -84,6 +85,7 @@ User.findById(req.params.id, function(err, user){
                                  Useful for protected attributes like fb.accessToken.
 - `defaultFilterRole` (String)(default: 'nofilter'):   Profile to use when one is not given, or the given profile does not exist.
 - `sanitize` (Boolean)(default: false):           True to automatically escape HTML in strings.
+- `compat` (Boolean)(default: false):             True to enable compatibility with Mongoose versions prior to 3.6
 
 ### Statics
 

--- a/lib/denormalize.js
+++ b/lib/denormalize.js
@@ -38,7 +38,7 @@
 */
 
 var mongoose    = require('mongoose'),
-    _           = require('underscore');
+    _           = require('lodash');
 
 module.exports = function denormalize(schema, options) {
     if(!options) options = {};

--- a/lib/denormalize.js
+++ b/lib/denormalize.js
@@ -11,7 +11,7 @@
 *
 * Example Usage:
 *
-* var denormalize = require('mongoose-denormalize-plugin');
+* var denormalize = require('mongoose-filter-denormalize').denormalize;
 * var ObjectId = mongoose.Schema.ObjectId;
 * var UserSchema = new Mongoose.schema({
 *   name            :   String,

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -103,7 +103,7 @@ module.exports = function filter(schema, options) {
 
     schema.statics.getReadFilterKeys = function(filterRole){
         var filters = this._getFilterKeys("readFilter", filterRole);
-        return filters ? filters.concat('_id') : filters; // Always send _id property
+        return (filters ? filters.concat('_id') : filters).join(' '); // Always send _id property
     };
 
     schema.statics.getWriteFilterKeys = function(filterRole){

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -96,14 +96,17 @@ module.exports = function filter(schema, options) {
 
     var defaults = {
         sanitize: false, // escapes HTML
-        defaultFilterRole : 'nofilter'
+        defaultFilterRole : 'nofilter',
+        compat: false
     };
 
     options = _.extend(defaults, options);
 
     schema.statics.getReadFilterKeys = function(filterRole){
         var filters = this._getFilterKeys("readFilter", filterRole);
-        return (filters ? filters.concat('_id') : filters).join(' '); // Always send _id property
+        filters = filters ? filters.concat('_id') : filters; // Always send _id property
+        if (options.compat) return filters;
+        else return filters.join(' ');
     };
 
     schema.statics.getWriteFilterKeys = function(filterRole){

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -89,7 +89,7 @@
 */
 
 var mongoose    = require('mongoose'),
-    _           = require('underscore'),
+    _           = require('lodash'),
     sanitizer   = require('sanitizer');
 
 module.exports = function filter(schema, options) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -35,7 +35,7 @@
 * ----- Environment: -----
 * -----              -----
 *
-* var filter = require('mongoose-filter-plugin');
+* var filter = require('mongoose-filter-denormalize').filter;
 * var ObjectId = mongoose.Schema.ObjectId;
 * var UserSchema = new Mongoose.schema({
 *   name            :   String,

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
-{ "name": "mongoose-filter-denormalize",
+{
+  "name": "mongoose-filter-denormalize",
   "version": "0.2.0",
   "description": "Simple collection filtering and denormalization.",
   "author": "Samuel Reed <samuel.trace.reed@gmail.com",
   "main": "index",
   "tags": "mongoose filter plugin",
-  "repository" : "git://github.com/STRML/mongoose-filter-denormalize",
-  "dependencies"    : {
-        "lodash"          : "~2.2.0",
-        "mongoose"        : "~3.6.0",
-        "sanitizer"       : "~0.1.0"
+  "repository": "git://github.com/STRML/mongoose-filter-denormalize",
+  "dependencies": {
+    "lodash": "~2.2.0",
+    "mongoose": "~3.6.0",
+    "sanitizer": "~0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "tags": "mongoose filter plugin",
   "repository" : "git://github.com/STRML/mongoose-filter-denormalize",
   "dependencies"    : {
-        "mongoose"        : "~3.0",
-        "sanitizer"       : "~0.0.15",
-        "underscore"      : "~1.3.1"
+        "lodash"          : "~2.2.0",
+        "mongoose"        : "~3.6.0",
+        "sanitizer"       : "~0.1.0"
   }
 }


### PR DESCRIPTION
`getReadFilterKeys` now returns a string-delineated list of filter params for compatibility with Mongoose 3.6.

A `compat` option was added (default `false`) for compatibility with versions prior to 3.6.

Updates the packages and switches from underscore to lodash for the extra speed.

Fixes #4
