### PR TITLE
FIX crash when nofilter & compat is false

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -106,7 +106,7 @@ module.exports = function filter(schema, options) {
         var filters = this._getFilterKeys("readFilter", filterRole);
         filters = filters ? filters.concat('_id') : filters; // Always send _id property
         if (options.compat) return filters;
-        else return filters.join(' ');
+	else return (filters) ? filters.join(' '): null;
     };
 
     schema.statics.getWriteFilterKeys = function(filterRole){


### PR DESCRIPTION
First of all, than you for this lib, it's very useful for me. I've found a crash when somebody sets as option _compat: false_ and doesn't specify defaultFilterRole or specify 'nofilter'.

As we can see on filter.js file, _getFilterKeys method:
`var filter = {nofilter: null};`

nofilter value is null, for that reason it crashes later on getReadFilterKeys method when:

`filters.join(' ');`